### PR TITLE
chore(backend): interfaceよりtypeを優先して使うようESLintのConfigを変更

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -18,6 +18,11 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.strict,
   ...tseslint.configs.stylistic,
+  {
+    rules: {
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+    },
+  },
   perfectionist.configs["recommended-natural"],
   unicorn.configs["flat/recommended"],
   {


### PR DESCRIPTION
close #141 

## Summary

This pull request includes a change to the ESLint configuration in `backend/eslint.config.js` to enforce consistent type definitions in TypeScript files.

* [`backend/eslint.config.js`](diffhunk://#diff-14040fab18d0c00709796de424d5f9ea0bdd624b4a812105b96b0abb09acfd86R21-R25): Added a rule to enforce the use of `type` for type definitions in TypeScript files.