### PR TITLE
docs: プロジェクト名をShuiroに変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
-  "name": "program-grading-system",
+  "name": "shuiro",
   "build": {
     "dockerfile": "../Dockerfile",
-    "cacheFrom": "ghcr.io/tus-project-team/program-grading-system-devcontainer:main",
+    "cacheFrom": "ghcr.io/shuiro-dev/shuiro-devcontainer:main",
     "args": {
       "UID": "1000",
       "GID": "1000"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Program Grading System
+# Shuiro
 
 プログラム採点システム
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# Program Grading System Backend
+# Shuiro Backend
 
 プログラム採点システムのAPIサーバーです。
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
-# Program Grading System Frontend
+# Shuiro Frontend
 
 プログラム採点システムのフロントエンドです。
 


### PR DESCRIPTION
This pull request includes changes to rebrand the project from "Program Grading System" to "Shuiro." The most important changes include updating the project name in various documentation files and the development container configuration.

Rebranding:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L2-R5): Updated the project name and Docker image reference to "shuiro" and "shuiro-devcontainer," respectively.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Changed the project title from "Program Grading System" to "Shuiro."
* [`backend/README.md`](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dL1-R1): Updated the backend documentation title to "Shuiro Backend."
* [`frontend/README.md`](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L1-R1): Updated the frontend documentation title to "Shuiro Frontend."