### PR TITLE
feat(backend): `deleteProblemRoute`を実装

### DIFF
--- a/backend/src/api/paths/problems.ts
+++ b/backend/src/api/paths/problems.ts
@@ -403,9 +403,66 @@ app.openapi(updateProblemRoute, async (c) => {
   } satisfies z.infer<typeof schemas.Problem>)
 })
 
-app.openapi(deleteProblemRoute, (c) => {
-  // TODO: 実際のデータベース削除処理を実装
-  return c.body(null, 204)
+app.openapi(deleteProblemRoute, async (c) => {
+  const { problemId } = c.req.valid("param")
+
+  try {
+    const problem = await prisma.problem.findUnique({
+      where: { id: problemId },
+    })
+
+    if (!problem) {
+      return c.body(null, 404)
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.testResult.deleteMany({
+        where: {
+          submission: {
+            problemId,
+          },
+        },
+      })
+
+      await tx.submissionResult.deleteMany({
+        where: {
+          submission: {
+            problemId,
+          },
+        },
+      })
+
+      await tx.submission.deleteMany({
+        where: { problemId },
+      })
+
+      await tx.testCase.deleteMany({
+        where: { problemId },
+      })
+
+      await tx.language.deleteMany({
+        where: { problemId },
+      })
+
+      await tx.problem.update({
+        data: {
+          teachers: {
+            set: [],
+          },
+        },
+        where: { id: problemId },
+      })
+
+      await tx.problem.delete({
+        where: { id: problemId },
+      })
+    })
+
+    return c.body(null, 204)
+  } catch (error) {
+    console.error("Problem deletion failed:", error)
+    return c.body(null, 500)
+  }
 })
 
 app.openapi(submitProgramRoute, async (c) => {


### PR DESCRIPTION
close #129 

## 確認事項

### 入力
```
curl --request POST \
  --url http://localhost:3000/api/problems \
  --header 'Content-Type: application/json' \
  --data '{
  "body": "任意の自然数が2つ与えられたら加算する。",
  "supported_languages": [
    {
      "name": "Rust",
      "version": "2021"
    }
  ],
  "test_cases": [
    {
      "input": "3 5",
      "output": "8"
    }
  ],
  "title": "plus"
}'
```

### 問題削除

```
curl --request DELETE \
  --url http://localhost:3000/api/problems/1
```

## Summary
This pull request includes significant changes to the `deleteProblemRoute` in the `backend/src/api/paths/problems.ts` file. The main focus is on implementing the actual database deletion logic for problems, ensuring that related data is also removed in a transactional manner. Additionally, error handling has been improved to handle potential issues during the deletion process.

### Implementation of Database Deletion Logic:

* [`backend/src/api/paths/problems.ts`](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL406-R465): Implemented the actual database deletion logic for `deleteProblemRoute`, ensuring that related data such as `testResult`, `submissionResult`, `submission`, `testCase`, and `language` entries are also deleted.

### Error Handling Improvements:

* [`backend/src/api/paths/problems.ts`](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL406-R465): Added error handling to log errors and return a 500 status code if the problem deletion fails.
