### PR TITLE
feat(backend): getSubmissionsRouteを実装

### DIFF
--- a/backend/src/api/paths/submissions.ts
+++ b/backend/src/api/paths/submissions.ts
@@ -1,8 +1,25 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { PrismaClient } from "@prisma/client"
 
-import { Submission } from "../components/schemas"
+import { Submission, SubmissionStatus, TestResult } from "../components/schemas"
 
 const app = new OpenAPIHono()
+const prisma = new PrismaClient()
+
+type SubmissionStatusType = z.infer<typeof SubmissionStatus>
+type TestStatusType = "Failed" | "Passed"
+
+const isValidSubmissionStatus = (
+  status: string,
+): status is SubmissionStatusType => {
+  return ["Accepted", "CompileError", "RuntimeError", "WrongAnswer"].includes(
+    status as SubmissionStatusType,
+  )
+}
+
+const isValidTestStatus = (status: string): status is TestStatusType => {
+  return ["Failed", "Passed"].includes(status as TestStatusType)
+}
 
 // パラメータスキーマの定義
 const SubmissionIdParam = z.object({
@@ -62,21 +79,66 @@ const getSubmissionByIdRoute = createRoute({
 })
 
 // ルートの設定
-app.openapi(getSubmissionsRoute, (c) => {
-  // TODO: 実際のデータベースクエリを実装
-  const submissions: z.infer<typeof Submission>[] = [
-    {
-      code: "print('Hello, World!')",
-      id: 1,
-      language: { name: "Python", version: "3.9" },
-      problem_id: 1,
-      result: { message: "テストケースにパスしました", status: "Accepted" },
-      student_id: 1,
-      submitted_at: new Date().toISOString(),
-      test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],
+app.openapi(getSubmissionsRoute, async (c) => {
+  const submissions = await prisma.submission.findMany({
+    include: {
+      language: true,
+      problem: true,
+      result: {
+        include: {
+          status: true,
+        },
+      },
+      testResults: {
+        include: {
+          status: true,
+          testCase: true,
+        },
+      },
     },
-  ]
-  return c.json(submissions)
+    orderBy: {
+      createdAt: "desc",
+    },
+  })
+
+  const formattedSubmissions = submissions.map((submission) => {
+    const submissionStatus = submission.result.status.status
+    if (!isValidSubmissionStatus(submissionStatus)) {
+      throw new Error(`Invalid submission status: ${submissionStatus}`)
+    }
+
+    const formattedTestResults = submission.testResults.map((result) => {
+      const testStatus = result.status.status
+      if (!isValidTestStatus(testStatus)) {
+        throw new Error(`Invalid test status: ${testStatus}`)
+      }
+
+      return {
+        message: result.message,
+        status: testStatus,
+        test_case_id: result.testCaseId,
+      } as z.infer<typeof TestResult>
+    })
+
+    return {
+      code: submission.code,
+      id: submission.id,
+      language: {
+        name: submission.languageName,
+        version: submission.languageVersion,
+      },
+      problem_id: submission.problemId,
+      result: {
+        message: submission.result.message,
+        status: submissionStatus,
+      },
+      student_id: submission.studentId,
+      submitted_at: submission.createdAt.toISOString(),
+      test_results: formattedTestResults,
+    } as z.infer<typeof Submission>
+  })
+
+  return c.json(formattedSubmissions)
 })
 
 app.openapi(getSubmissionByIdRoute, (c) => {


### PR DESCRIPTION
close #132

## 確認事項
### 新しい問題を作成する
```
curl --request POST \
  --url http://localhost:3000/api/problems \
  --header 'Content-Type: application/json' \
  --data '{
  "body": "HelloとWorldを出力する",
  "supported_languages": [
    {
      "name": "Python",
      "version": "3.12"
    }
  ],
  "test_cases": [
    {
      "input": "",
      "output": "Hello World!"
    }
  ],
  "title": "hello-world"
}'
```

### 提出する
```
curl --request POST \
  --url http://localhost:3000/api/problems/1/submit \
  --header 'Content-Type: application/json' \
  --data '{
  "code": "print(\"Hello World!\")",
  "language": {
    "name": "Python",
    "version": "3.12"
  }
}'
```

### 提出一覧を取得する

- [ ] 入力
```
curl --request GET \
  --url http://localhost:3000/api/submissions
```

- [ ] 出力
```
[
  {
    "code": "print(\"Hello World!\")",
    "id": 1,
    "language": {
      "name": "Python",
      "version": "3.12"
    },
    "problem_id": 1,
    "result": {
      "message": "テストケースにパスしました",
      "status": "Accepted"
    },
    "student_id": 1,
    "submitted_at": "2024-11-01T04:12:07.473Z",
    "test_results": [
      {
        "message": "",
        "status": "Passed",
        "test_case_id": 1
      }
    ]
  }
]
```

## Summary
This pull request to `backend/src/api/paths/submissions.ts` includes significant updates to integrate Prisma for database queries and validate submission and test statuses. The most important changes include importing Prisma, defining types and validation functions for statuses, and implementing actual database queries in the route handlers.

Integration of Prisma and validation:

* Added import for `PrismaClient` and instantiated it for database interactions.
* Defined `SubmissionStatusType` and `TestStatusType` types, and created `isValidSubmissionStatus` and `isValidTestStatus` functions for status validation.

Database query implementation:

* Replaced the static list of submissions with an actual database query using Prisma in the `getSubmissionsRoute` handler.
* Included related entities such as language, problem, result, and test results in the query, and formatted the results to match the expected schema.
